### PR TITLE
[Closes #88] Adds pagination to Users, Routes, and Maintenance Requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rails', '4.2.3'
 gem 'puma'
 gem 'pg'
 gem 'pundit'
+gem 'kaminari'
 
 gem 'aws-sdk'
 gem "paperclip"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,9 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     json_pure (1.8.3)
+    kaminari (0.16.3)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     loofah (2.0.3)
@@ -240,6 +243,7 @@ DEPENDENCIES
   ffaker
   jbuilder (~> 2.0)
   jquery-rails
+  kaminari
   paperclip
   pg
   puma

--- a/app/controllers/maintenance_requests_controller.rb
+++ b/app/controllers/maintenance_requests_controller.rb
@@ -8,6 +8,7 @@ class MaintenanceRequestsController < ApplicationController
     @requests = MaintenanceRequest.joins(:user, :route).all
     @requests = @requests.order(sort_column + " " + sort_direction)
     @requests = @requests.not_resolved
+    @requests = @requests.page(params[:page])
   end
 
   def show

--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -7,6 +7,7 @@ class RoutesController < ApplicationController
     @routes = Route.joins(:user).active_routes
     @routes = @routes.with_full_text_search(params[:search]) if params[:search].present?
     @routes = @routes.order(sort_column + " " + sort_direction)
+    @routes = @routes.page(params[:page])
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,7 @@ class UsersController < ApplicationController
     @users = User.where(nil)
     @users = @users.with_full_text_search(params[:search]) if params[:search].present?
     @users = @users.order(sort_column + " " + sort_direction)
+    @users = @users.page(params[:page])
   end
 
   def show

--- a/app/views/maintenance_requests/index.html.erb
+++ b/app/views/maintenance_requests/index.html.erb
@@ -24,3 +24,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= paginate @requests %>

--- a/app/views/routes/index.html.erb
+++ b/app/views/routes/index.html.erb
@@ -49,3 +49,5 @@
     </tbody>
   </table>
 </div>
+
+<%= paginate @routes %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -35,3 +35,5 @@
     </tbody>
   </table>
 </div>
+
+<%= paginate @users %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,10 @@
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+end


### PR DESCRIPTION
- This doesn't cover `Expiring Routes` because that code isn't in place yet.
- Ended up doing the default style because the Bootstrap pagination is too wide on many phone screens.

<img width="347" alt="screen shot 2016-04-08 at 9 28 28 am" src="https://cloud.githubusercontent.com/assets/2058205/14390498/46938108-fd6c-11e5-929b-fe71d87ddfcc.png">
