### PR TITLE
Adds expiring routes

### DIFF
--- a/app/controllers/admin/expiring_routes_controller.rb
+++ b/app/controllers/admin/expiring_routes_controller.rb
@@ -1,0 +1,22 @@
+module Admin
+  class ExpiringRoutesController < ApplicationController
+    helper_method :sort_column, :sort_direction
+
+    def index
+      @routes = Route.joins(:user).active_routes.expiring
+      @routes = @routes.order(sort_column + " " + sort_direction)
+      @routes = @routes.page(params[:page])
+    end
+
+    private
+
+    def sort_column
+      whitelist = %w(label name users.first_name location tape_color grade route_set_date expiration_date)
+      whitelist.include?(params[:sort]) ? params[:sort] : "expiration_date"
+    end
+
+    def sort_direction
+      %w(asc desc).include?(params[:direction]) ?  params[:direction] : "asc"
+    end
+  end
+end

--- a/app/helpers/expiring_route_helper.rb
+++ b/app/helpers/expiring_route_helper.rb
@@ -1,0 +1,2 @@
+module ExpiringRouteHelper
+end

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -50,6 +50,10 @@ class Route < ActiveRecord::Base
     where(status: 0)
   end
 
+  def self.expiring
+    where('expiration_date < ?', 2.weeks.from_now.to_s)
+  end
+
   def self.expired_routes
     where('expiration_date < ?', Date.today.to_s)
   end

--- a/app/policies/announcement_policy.rb
+++ b/app/policies/announcement_policy.rb
@@ -1,48 +1,42 @@
 class AnnouncementPolicy < ApplicationPolicy
-  attr_reader :announcement, :record
-
-  def initialize(current_user, announcement)
-    @current_user = current_user
-    @announcement = announcement
-  end
 
   def index?
-    @current_user.role != "Public"
+    @user.role != "Public"
   end
 
   def new?
-    @current_user.role != "Public" and
-    @current_user.role != "Setter" and
-    @current_user.role != "Employee"
+    @user.role != "Public" and
+    @user.role != "Setter" and
+    @user.role != "Employee"
   end
 
   def create?
-    @current_user.role != "Public" and
-    @current_user.role != "Setter" and
-    @current_user.role != "Employee"
+    @user.role != "Public" and
+    @user.role != "Setter" and
+    @user.role != "Employee"
   end
 
   def show?
-    @current_user.role != "Public" and
-    @current_user.role != "Setter" and
-    @current_user.role != "Employee"
+    @user.role != "Public" and
+    @user.role != "Setter" and
+    @user.role != "Employee"
   end
 
   def update?
-    @current_user.role != "Public" and
-    @current_user.role != "Setter" and
-    @current_user.role != "Employee"
+    @user.role != "Public" and
+    @user.role != "Setter" and
+    @user.role != "Employee"
   end
 
   def edit?
-    @current_user.role != "Public" and
-    @current_user.role != "Setter" and
-    @current_user.role != "Employee"
+    @user.role != "Public" and
+    @user.role != "Setter" and
+    @user.role != "Employee"
   end
 
   def destroy?
-    @current_user.role != "Public" and
-    @current_user.role != "Setter" and
-    @current_user.role != "Employee"
+    @user.role != "Public" and
+    @user.role != "Setter" and
+    @user.role != "Employee"
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -2,6 +2,7 @@ class ApplicationPolicy
   attr_reader :user, :record
 
   def initialize(user, record)
+    raise Pundit::NotAuthorizedError, "must be logged in" unless user
     @user = user
     @record = record
   end

--- a/app/policies/assigned_route_policy.rb
+++ b/app/policies/assigned_route_policy.rb
@@ -1,26 +1,20 @@
 class AssignedRoutePolicy < ApplicationPolicy
-  attr_reader :assigned_route, :record
-
-  def initialize(current_user, assigned_route)
-    @current_user = current_user
-    @assigned_route = assigned_route
-  end
 
   def create?
-    @current_user.role != "Public"
+    @user.role != "Public"
   end
 
   def edit?
     # Supervisors and up, or the owner of the route
-    (@current_user.role != "Public" and @current_user.role != "Setter" and
-     @current_user.role != "Employee") or
-     @current_user.id == @route.user_id
+    (@user.role != "Public" and @user.role != "Setter" and
+     @user.role != "Employee") or
+     @user.id == @record.user_id
   end
 
   def update?
     # Supervisors and up, or the owner of the route
-    (@current_user.role != "Public" and @current_user.role != "Setter" and
-     @current_user.role != "Employee") or
-     @current_user.id == @route.user_id
+    (@user.role != "Public" and @user.role != "Setter" and
+     @user.role != "Employee") or
+     @user.id == @record.user_id
   end
 end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,13 +1,7 @@
 class CommentPolicy < ApplicationPolicy
-  attr_reader :comment, :record
-
-  def initialize(current_user, comment)
-    @current_user = current_user
-    @comment = comment
-  end
 
   def create?
-    @current_user.role != "Public" and
-    @current_user.id === @comment.user_id
+    @user.role != "Public" and
+    @user.id === @record.user_id
   end
 end

--- a/app/policies/maintenance_request_policy.rb
+++ b/app/policies/maintenance_request_policy.rb
@@ -1,49 +1,43 @@
 class MaintenanceRequestPolicy < ApplicationPolicy
-  attr_reader :request, :record
-
-  def initialize(current_user, request)
-    @current_user = current_user
-    @request = request
-  end
 
   def index?
-    @current_user.role != "Public"
+    @user.role != "Public"
   end
 
   def show?
-    @current_user.role != "Public"
+    @user.role != "Public"
   end
 
   def new?
-    @current_user.role != "Public"
+    @user.role != "Public"
   end
 
   def create?
-    @current_user.role != "Public"
+    @user.role != "Public"
   end
 
   def edit?
     # Supervisors and up, or the owner of the request
-    (@current_user.role != "Public" and @current_user.role != "Setter" and
-     @current_user.role != "Employee") or
-     @current_user.id == @request.user_id
+    (@user.role != "Public" and @user.role != "Setter" and
+     @user.role != "Employee") or
+     @user.id == @record.user_id
   end
 
   def update?
     # Supervisors and up, or the owner of the request
-    (@current_user.role != "Public" and @current_user.role != "Setter" and
-     @current_user.role != "Employee") or
-     @current_user.id == @request.user_id
+    (@user.role != "Public" and @user.role != "Setter" and
+     @user.role != "Employee") or
+     @user.id == @record.user_id
   end
 
   def resolve?
-    @current_user.role != "Public"
+    @user.role != "Public"
   end
 
   def destroy?
     # Supervisors and up, or the owner of the request
-    (@current_user.role != "Public" and @current_user.role != "Setter" and
-     @current_user.role != "Employee") or
-     @current_user.id == @request.user_id
+    (@user.role != "Public" and @user.role != "Setter" and
+     @user.role != "Employee") or
+     @user.id == @record.user_id
   end
 end

--- a/app/policies/rating_policy.rb
+++ b/app/policies/rating_policy.rb
@@ -1,8 +1,3 @@
 class RatingPolicy < ApplicationPolicy
-  attr_reader :rating, :record
 
-  def initialize(current_user, rating)
-    @current_user = current_user
-    @rating = rating
-  end
 end

--- a/app/policies/route_policy.rb
+++ b/app/policies/route_policy.rb
@@ -1,41 +1,35 @@
 class RoutePolicy < ApplicationPolicy
-  attr_reader :route, :record
-
-  def initialize(current_user, route)
-    @current_user = current_user
-    @route = route
-  end
 
   # only needed for assigned routes
   def index?
-    @current_user.role != "Public"
+    @user.role != "Public"
   end
 
   def new?
-    @current_user.role != "Public"
+    @user.role != "Public"
   end
 
   def create?
-    @current_user.role != "Public"
+    @user.role != "Public"
   end
 
   def edit?
     # Supervisors and up, or the owner of the route
-    (@current_user.role != "Public" and @current_user.role != "Setter" and
-     @current_user.role != "Employee") or
-     @current_user.id == @route.user_id
+    (@user.role != "Public" and @user.role != "Setter" and
+     @user.role != "Employee") or
+     @user.id == @record.user_id
   end
 
   def update?
     # Supervisors and up, or the owner of the route
-    (@current_user.role != "Public" and @current_user.role != "Setter" and
-     @current_user.role != "Employee") or
-     @current_user.id == @route.user_id
+    (@user.role != "Public" and @user.role != "Setter" and
+     @user.role != "Employee") or
+     @user.id == @record.user_id
   end
 
   def destroy?
-    (@current_user.role != "Public" and @current_user.role != "Setter" and
-     @current_user.role != "Employee") or
-     @current_user.id == @route.user_id
+    (@user.role != "Public" and @user.role != "Setter" and
+     @user.role != "Employee") or
+     @user.id == @record.user_id
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,16 +1,9 @@
 class UserPolicy < ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(current_user, user)
-    @current_user = current_user
-    @user = user
-  end
-
   def edit?
-    @current_user.id === @user.id
+    @user.id === @record.id
   end
 
   def update?
-    @current_user.id === @user.id
+    @user.id === @record.id
   end
 end

--- a/app/views/admin/expiring_routes/index.html.erb
+++ b/app/views/admin/expiring_routes/index.html.erb
@@ -1,0 +1,37 @@
+<h1>Expiring Routes</h1>
+
+<br>
+
+<div class="table-responsive">
+  <table class="table">
+    <thead>
+      <%= sortable_header "name", "Name" %>
+      <%= sortable_header "label", "Label" %>
+      <%= sortable_header "users.first_name", "Setter" %>
+      <%= sortable_header "location" %>
+      <%= sortable_header "tape_color", "Color" %>
+      <%= sortable_header "route_set_date", "Set Date" %>
+      <%= sortable_header "expiration_date" %>
+      <%= sortable_header "grade" %>
+    </thead>
+    <tbody>
+      <% @routes.each do |route| %>
+      <%
+        # need to assign a class based on expiration date
+      %>
+        <tr class="<%= route.expiration_date < Date.today ? 'danger' : '' %>">
+          <td><%= link_to highlight(route.name, params[:search]), [:admin, route] %></td>
+          <td><%= highlight route.label.to_s, params[:search] %></td>
+          <td><%= link_to highlight(route.user.name, params[:search]), [:admin, route.user] %></td>
+          <td><%= highlight route.location, params[:search] %></td>
+          <td><%= highlight route.tape_color, params[:search] %></td>
+          <td><%= route.route_set_date.strftime("%b %d, %Y") %></td>
+          <td><%= route.expiration_date.strftime("%b %d, %Y") %></td>
+          <td><%= route.grade %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<%= paginate @routes %>

--- a/app/views/admin/routes/_form.html.erb
+++ b/app/views/admin/routes/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @form, html: { multipart: true } do |f| %>
+<%= form_for [:admin, @form], html: { multipart: true } do |f| %>
   <div class="row">
     <div class="col-sm-6">
       <div class="form-group">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -45,9 +45,7 @@
                 </a>
                 <ul class="dropdown-menu">
                   <li><%= link_to "Assigned Routes", admin_assigned_routes_path %></li>
-                  <!--
-                  <li><%#= link_to "Expiring Routes", admin_expiring_routes_path %></li>
-                  -->
+                  <li><%= link_to "Expiring Routes", admin_expiring_routes_path %></li>
                 </ul>
               </li>
             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       resources :comments
     end
     resources :assigned_routes
+    resources :expiring_routes
     resources :ratings
     resources :maintenance_requests do
       member do


### PR DESCRIPTION
closes #24

simple ui for viewing routes that are considered 'expired'. This information can easily be viewed in the routes index page if you just filter by date ascending, but they like this because it serves as a report of what needs to come down. 
