### PR TITLE
fixes displaying disabled routes in graphs, and perms for editing users

### DIFF
--- a/app/controllers/admin/charts_controller.rb
+++ b/app/controllers/admin/charts_controller.rb
@@ -17,7 +17,7 @@ module Admin
     end
 
     def expired_routes
-      Route.expired_routes.location(params[:location]).group(:grade).count
+      Route.active_routes.expired_routes.location(params[:location]).group(:grade).count
         .map { |key, value| [Route.grades.select { |gkey, gvalue| gvalue == key }.keys.first, value] }
     end
 

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -3,13 +3,15 @@ class UserPolicy < ApplicationPolicy
     @user.role != "Public"
   end
 
+  ## managers and admins can edit anyone, supervisors can edit anyone that's not
+  ## an admin or a supervisor.
   def edit?
     @user.role == "Manager" || @user.role == "Administrator" ||
-    @user.role == "Supervisor"
+    (@user.role == "Supervisor" && (@record.role != "Manager" && @record.role != "Administrator"))
   end
 
   def update?
     @user.role == "Manager" || @user.role == "Administrator" ||
-    @user.role == "Supervisor"
+    (@user.role == "Supervisor" && (@record.role != "Manager" && @record.role != "Administrator"))
   end
 end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -16,7 +16,7 @@
       </div>
       <div class="form-group">
         <%= f.label :role %><br />
-        <%= f.select :role, User.roles.keys, { include_blank: true }, class: "form-control" %>
+        <%= f.select :role, (current_user.role == "Supervisor") ? ["Public", "Setter", "Employee", "Supervisor"] : User.roles.keys, { include_blank: true }, class: "form-control" %>
       </div>
       <div class="form-group">
         <%= f.submit "Update", class: "btn btn-primary" %>


### PR DESCRIPTION
- fixes displaying disabled routes in the expired portion of charts
- allows admins and managers to edit any user, and sup's to edit anyone who's not an admin or manager.
