### PR TITLE
hides hidden users from route dropdowns and view.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,8 @@ class User < ActiveRecord::Base
 
   def self.setters
     active
-    .where('role <> 0').order(:first_name)
+    .where('role <> 0')
+    .order(:first_name)
   end
 
   # TODO Replace with ActiveRecord #or with Rails 5

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,8 @@ class User < ActiveRecord::Base
   end
 
   def self.setters
-    where('role <> 0').order(:first_name)
+    active
+    .where('role <> 0').order(:first_name)
   end
 
   # TODO Replace with ActiveRecord #or with Rails 5
@@ -35,6 +36,6 @@ class User < ActiveRecord::Base
   end
 
   def self.active
-    where(hidden: nil)
+    where(is_deleted: false)
   end
 end

--- a/db/migrate/20160805165953_change_users_hidden_column.rb
+++ b/db/migrate/20160805165953_change_users_hidden_column.rb
@@ -1,0 +1,6 @@
+class ChangeUsersHiddenColumn < ActiveRecord::Migration
+  def change
+    remove_column :users, :hidden
+    add_column :users, :is_deleted, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160723182256) do
+ActiveRecord::Schema.define(version: 20160805165953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,24 +92,24 @@ ActiveRecord::Schema.define(version: 20160723182256) do
   create_table "users", force: :cascade do |t|
     t.string   "first_name"
     t.string   "last_name"
-    t.string   "email",                              default: "", null: false
-    t.string   "encrypted_password",                 default: "", null: false
+    t.string   "email",                              default: "",    null: false
+    t.string   "encrypted_password",                 default: "",    null: false
     t.integer  "role",                               default: 0
-    t.integer  "hidden"
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                      default: 0,  null: false
+    t.integer  "sign_in_count",                      default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at",                                      null: false
-    t.datetime "updated_at",                                      null: false
+    t.datetime "created_at",                                         null: false
+    t.datetime "updated_at",                                         null: false
     t.integer  "routes_count",                       default: 0
     t.integer  "announcements_count",                default: 0
     t.string   "confirmation_token",     limit: 128
     t.string   "remember_token",         limit: 128
+    t.boolean  "is_deleted",                         default: false, null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
Changes the users column `hidden` to `is_deleted`. Users that are hidden will be kept from immediate view, but still available via navigation from route owner. Future dev will restrict login on `is_deleted` status, but not just yet since we don't have the functionality to delete a user yet. 
