### PR TITLE
Fix enum key typo

### DIFF
--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,11 +1,10 @@
 class Rating < ActiveRecord::Base
 
-  # associations
   belongs_to :route, inverse_of: :ratings
   belongs_to :user, inverse_of: :ratings
 
   enum ratings: {
-    :"2"   => 1,
+    :"1"   => 1,
     :"2"   => 2,
     :"3"   => 3,
     :"4"   => 4,


### PR DESCRIPTION
Looks like there was a typo here, was throwing a warning
