### PR TITLE
redirects back to 'Assigned Routes' report view after successful destroy

### DIFF
--- a/app/policies/assigned_route_policy.rb
+++ b/app/policies/assigned_route_policy.rb
@@ -1,5 +1,4 @@
 class AssignedRoutePolicy < ApplicationPolicy
-
   def create?
     @user.role != "Public"
   end
@@ -17,4 +16,10 @@ class AssignedRoutePolicy < ApplicationPolicy
      @user.role != "Employee") or
      @user.id == @record.user_id
   end
+
+  def destroy?
+    # Supervisors and up
+    (@user.role != "Public" and @user.role != "Setter" and
+     @user.role != "Employee")
+   end
 end

--- a/app/views/admin/assigned_routes/edit.html.erb
+++ b/app/views/admin/assigned_routes/edit.html.erb
@@ -77,8 +77,8 @@
     <div class="form-group">
       <%= f.submit :submit, value: "Complete Route", class: "btn btn-success" %>
 
-      <% if policy(@route).destroy? %>
-        <%= link_to "Remove Assignment", [:admin, @route],
+      <% if policy(:assigned_route).destroy? %>
+        <%= link_to "Remove Assignment", [:admin, :assigned_route],
           class: "btn btn-danger", method: :delete,
           data: { confirm: "Are you sure you'd like to remove this assignment?" }
         %>

--- a/app/views/admin/assigned_routes/edit.html.erb
+++ b/app/views/admin/assigned_routes/edit.html.erb
@@ -77,8 +77,8 @@
     <div class="form-group">
       <%= f.submit :submit, value: "Complete Route", class: "btn btn-success" %>
 
-      <% if policy(:assigned_route).destroy? %>
-        <%= link_to "Remove Assignment", [:admin, :assigned_route],
+      <% if policy(@form).destroy? %>
+        <%= link_to "Remove Assignment", admin_assigned_route_path(@form),
           class: "btn btn-danger", method: :delete,
           data: { confirm: "Are you sure you'd like to remove this assignment?" }
         %>


### PR DESCRIPTION
closes #175 