### PR TITLE
Use `simple_format` for announcement formatting

### DIFF
--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class HomeController < ApplicationController
     def index
+      @announcements = Announcement.not_expired
       @top_setters = User.top_setters
     end
   end

--- a/app/views/admin/announcements/show.html.erb
+++ b/app/views/admin/announcements/show.html.erb
@@ -11,7 +11,7 @@
 
   <div class="panel panel-default">
     <div class="panel-body">
-      <%= @announcement.body %>
+      <%= simple_format(@announcement.body) %>
     </div>
     <table class="table">
       <tbody>

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -1,37 +1,38 @@
 <h1>Oregon State Indoor Climbing Center Administrator Site</h1>
-<div class="jumbotron">
-  <h1>Coming Soon!</h1>
-  <p>
-    It's been our goal to get this web tool available to the gym for some time now.
-    In order to have it ready and accessible for setting this summer, we've shoved off some quality of life features, such as:
-  </p>
-  <ul>
-    <li>advanced setting metrics (this page) for an overall status of the gym</li>
-    <li>events tracking</li>
-    <li>auto-generation of route labels</li>
-    <li>and more!</li>
-  </ul>
-  <p>
-    We appreciate your patience and would absolutely <b>love</b> any feedback or suggestions!
-  </p>
-</div>
 
-<div class="col-md-4">
-  <h3>Top Setters</h3>
-  <ul class="list-group">
-    <% @top_setters.each do |user| %>
-      <li class="list-group-item">
-        <%= link_to truncate(user.name, length: 25), [:admin, user] %>
-        <div class="pull-right">
-          <select class="multi_rating" data-rating="<%= user.rating %>">
-            <option value="1">1</option>
-            <option value="2">2</option>
-            <option value="3">3</option>
-            <option value="4">4</option>
-            <option value="5">5</option>
-          </select>
-        </div>
-      </li>
+<div class="row">
+  <div class="col-md-6">
+    <h3>Announcements</h3>
+    <% @announcements.each do |announcement| %>
+    <div class="media">
+      <div class="media-body">
+        <h4 class="media-heading">
+          <%= announcement.subject %>
+          <small><%= announcement.reveal_date.strftime("%b %d, %Y") %></small>
+        </h4>
+        <%= simple_format(announcement.body) %>
+      </div>
+    </div>
     <% end %>
-  </ul>
+  </div>
+
+  <div class="col-md-6">
+    <h3>Top Setters</h3>
+    <ul class="list-group">
+      <% @top_setters.each do |user| %>
+        <li class="list-group-item">
+          <%= link_to truncate(user.name, length: 25), [:admin, user] %>
+          <div class="pull-right">
+            <select class="multi_rating" data-rating="<%= user.rating %>">
+              <option value="1">1</option>
+              <option value="2">2</option>
+              <option value="3">3</option>
+              <option value="4">4</option>
+              <option value="5">5</option>
+            </select>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  </div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -36,7 +36,7 @@
             <%= announcement.subject %>
             <small><%= announcement.reveal_date.strftime("%b %d, %Y") %></small>
           </h4>
-          <%= announcement.body %>
+          <%= simple_format(announcement.body) %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
This formatter preserves newlines so we can do bullets like below:

<img width="1346" alt="screen shot 2016-11-26 at 5 36 48 pm" src="https://cloud.githubusercontent.com/assets/2058205/20644956/2e9dec7e-b3ff-11e6-92cd-b4065344d8c7.png">


Adds to public homepage, admin homepage, and announcements show page